### PR TITLE
Allow to have attr on first `<section>` elements.

### DIFF
--- a/sphinx_revealjs/writers.py
+++ b/sphinx_revealjs/writers.py
@@ -44,15 +44,17 @@ class RevealjsSlideTranslator(HTML5Translator):
         if self.section_level == 1:
             self.builder.revealjs_slide = find_child_section(node, "revealjs_slide")
             self._proc_first_on_section = True
-            self.body.append("<section>\n")
+            self.body.append(f"<section {attrs}>\n")
             return
         if self._proc_first_on_section:
             self._proc_first_on_section = False
             self.body.append("</section>\n")
-        self.body.append(f"<section {attrs}>\n")
+
         if has_child_sections(node, "section"):
             self._proc_first_on_section = True
             self.body.append("<section>\n")
+
+        self.body.append(f"<section {attrs}>\n")
 
     def depart_section(self, node: section):
         """End ``section``.


### PR DESCRIPTION
Attributes for `.. revealjs_section::` doesn't work on first section of a group. For example, `data-background-color` doesn't work on the first slide, the title one.

Also when you set a `data-background-color` under header level 2, the background apply to the bounding `<section>`, so all sub sections get this background color.

Now, attributes are set to the first no-bounding `<section>`. So `data-background-color` works on the title slide and it applies on the header level 2 slides.