### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/configurations.rst
+++ b/docs/configurations.rst
@@ -136,7 +136,7 @@ revealjs_script_plugins
 :Optional:
 :Default: ``[]``
 
-List of pulugin configurations.
+List of plugin configurations.
 If this value is set, render ``script`` tag after source script tags.
 
 There are bundled Reveal.js plugins at ``revealjs/plugin``.

--- a/docs/customize_sections.rst
+++ b/docs/customize_sections.rst
@@ -28,7 +28,7 @@ Write ``revealjs_slide`` directive on directly below of section title header.
 Attributes
 ----------
 
-This direcvite can accept attribute as same as Reveal.js ``section`` tags.
+This directive can accept attribute as same as Reveal.js ``section`` tags.
 
 revealjs_break
 ==============

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ Basic Features
 Demo
 ====
 
-* Sourece: `Sphinx document <https://github.com/attakei/sphinx-revealjs/tree/master/demo>`_
+* Source: `Sphinx document <https://github.com/attakei/sphinx-revealjs/tree/master/demo>`_
 * Created: `Reveal.js presentation <https://attakei.github.io/sphinx-revealjs/>`_
 
 .. container:: flex
@@ -56,15 +56,15 @@ Goal of this library is to provide presentation platform
 for self-branding of engineer using Sphinx.
 Using static site hosting service, you can show own presentations to anyone.
 
-Core motivation is that I want to play plesentation by this library.
+Core motivation is that I want to play presentation by this library.
 
-Liceses
-=======
+Licenses
+========
 
-This library is licensed Apache License verion 2.0.
+This library is licensed Apache License version 2.0.
 
 About license of directly dependencies,
-please see each software projects or documententions.
+please see each software projects or documentations.
 
 * docutils:
 

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -36,7 +36,7 @@ and need update ``revealjs_script_plugins`` .
         },
     ]
 
-* Changed struct from src and options to src and name.
+* Changed structure from src and options to src and name.
 
   * | For 4.x, to use plugin for core,
     | add class name of it not source path,
@@ -50,7 +50,7 @@ MORE: See `Using Plugins from Reveal.js document <https://revealjs.com/plugins/>
 revealjs_css_files
 ------------------
 
-If you use highlight plugin and sepecify bundled stylesheet file,
+If you use highlight plugin and specify bundled stylesheet file,
 change path of stylesheet.
 Style files is migrated to highlight plugin folder.
 


### PR DESCRIPTION
I noticed some typos using the VSCode extension, [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker).

~I fixed a few things, but docs has a lot of files.
Sorry, I don't think I've covered them all right now.~

~I don't mind if you merge this, but I'll check the rest typo later.~
(updated) I checked the rest of rst files under the docs directory with the spell checker.
