### PR TITLE
Theme CSS now comes before user-defined CSS in the head tag

### DIFF
--- a/sphinx_revealjs/builders.py
+++ b/sphinx_revealjs/builders.py
@@ -98,7 +98,10 @@ class RevealjsHTMLBuilder(StandaloneHTMLBuilder):
             theme = f"_static/{theme}"
         else:
             theme = f"_static/{self.revealjs_context.engine.theme_dir}/{theme}.css"
-        ctx["css_files"].append(theme)
+        # index 0: "_static/revealjs4/dist/reveal.css"
+        # index 1: theme css file path
+        # index 2 or later: other css files
+        ctx["css_files"].insert(1, theme)
 
     def configure_fonts(self, ctx: Dict):
         """Find and add google-fonts settins from conf and directive."""

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -156,3 +156,24 @@ class BuildHtmlTests(unittest.TestCase):  # noqa
         ]
         self.assertEqual(len(links), 1)
         self.assertTrue((app.outdir / "_static/custom.css").exists())
+
+    @with_app(
+        **gen_app_conf(
+            confoverrides={
+                "revealjs_static_path": ["_static"],
+                "revealjs_css_files": ["custom.css"],
+            }
+        )
+    )
+    def test_default_theme_css_comes_before_custom_css(
+        self, app: TestApp, status, warning
+    ):
+        soup = soup_html(app, "index.html")
+        stylesheet_href_list = [
+            e["href"] for e in soup.find_all("link", rel="stylesheet")
+        ]
+        default_theme_index = stylesheet_href_list.index(
+            "_static/revealjs4/dist/theme/black.css"
+        )
+        custom_css_index = stylesheet_href_list.index("_static/custom.css")
+        self.assertTrue(default_theme_index < custom_css_index)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -177,3 +177,25 @@ class BuildHtmlTests(unittest.TestCase):  # noqa
         )
         custom_css_index = stylesheet_href_list.index("_static/custom.css")
         self.assertTrue(default_theme_index < custom_css_index)
+
+    @with_app(
+        **gen_app_conf(
+            confoverrides={
+                "revealjs_style_theme": "moon",
+                "revealjs_static_path": ["_static"],
+                "revealjs_css_files": ["other_custom.css"],
+            }
+        )
+    )
+    def test_specified_theme_css_comes_before_custom_css(
+        self, app: TestApp, status, warning
+    ):
+        soup = soup_html(app, "index.html")
+        stylesheet_href_list = [
+            e["href"] for e in soup.find_all("link", rel="stylesheet")
+        ]
+        specified_theme_index = stylesheet_href_list.index(
+            "_static/revealjs4/dist/theme/moon.css"
+        )
+        custom_css_index = stylesheet_href_list.index("_static/other_custom.css")
+        self.assertTrue(specified_theme_index < custom_css_index)


### PR DESCRIPTION
Resolve https://github.com/attakei/sphinx-revealjs/issues/40

Theme CSS comes before user-defined CSS for users to overwrite some properties defined in theme CSS with their own CSS