### PR TITLE
fix typo under tests directory

### DIFF
--- a/tests/test_demo_revealjs4.py
+++ b/tests/test_demo_revealjs4.py
@@ -1,4 +1,4 @@
-"""Integrationaly tests by demo/revealjs4."""
+"""Integration tests by demo/revealjs4."""
 import unittest
 
 from sphinx_testing import TestApp

--- a/tests/test_revealjs_fragments.py
+++ b/tests/test_revealjs_fragments.py
@@ -6,7 +6,7 @@ from sphinx_testing import TestApp, with_app
 from testutils import gen_app_conf, soup_html
 
 
-class BuidHtmlTests(unittest.TestCase):  # noqa
+class BuildHtmlTests(unittest.TestCase):  # noqa
     @with_app(**gen_app_conf())
     def test_fragments_generate(self, app: TestApp, status, warning):  # noqa
         soup = soup_html(app, "has_fragments.html")

--- a/tests/test_revealjs_slide.py
+++ b/tests/test_revealjs_slide.py
@@ -6,7 +6,7 @@ from sphinx_testing import TestApp, with_app
 from testutils import gen_app_conf, soup_html
 
 
-class BuidHtmlTests(unittest.TestCase):  # noqa
+class BuildHtmlTests(unittest.TestCase):  # noqa
     @with_app(**gen_app_conf())
     def test_override_theme(self, app: TestApp, status, warning):  # noqa
         soup = soup_html(app, "with_theme.html")

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,4 +1,4 @@
-"""Test supprto functions."""
+"""Test support functions."""
 from pathlib import Path
 from typing import AnyStr
 


### PR DESCRIPTION
I noticed some typos in test codes with VSCode [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) extension