### PR TITLE
Add id to slide sections.

### DIFF
--- a/sphinx_revealjs/writers.py
+++ b/sphinx_revealjs/writers.py
@@ -41,6 +41,8 @@ class RevealjsSlideTranslator(HTML5Translator):
             attrs = meta.attributes_str()
         else:
             attrs = ""
+        if node.attributes.get('ids'):
+            attrs += ' id="{}"'.format(node.attributes['ids'][-1])
         if self.section_level == 1:
             self.builder.revealjs_slide = find_child_section(node, "revealjs_slide")
             self._proc_first_on_section = True
@@ -53,7 +55,6 @@ class RevealjsSlideTranslator(HTML5Translator):
         if has_child_sections(node, "section"):
             self._proc_first_on_section = True
             self.body.append("<section>\n")
-
         self.body.append(f"<section {attrs}>\n")
 
     def depart_section(self, node: section):

--- a/sphinx_revealjs/writers.py
+++ b/sphinx_revealjs/writers.py
@@ -41,8 +41,8 @@ class RevealjsSlideTranslator(HTML5Translator):
             attrs = meta.attributes_str()
         else:
             attrs = ""
-        if node.attributes.get('ids'):
-            attrs += ' id="{}"'.format(node.attributes['ids'][-1])
+        if node.attributes.get("ids"):
+            attrs += ' id="{}"'.format(node.attributes["ids"][-1])
         if self.section_level == 1:
             self.builder.revealjs_slide = find_child_section(node, "revealjs_slide")
             self._proc_first_on_section = True


### PR DESCRIPTION
This change includes the section id in the presentation to allow adding custom css and allowing fixed urls to a slide. For example the following slide:

```rst
My Section
=========
```

It has the id "my-section". The next slide:

```rst
.. _other-section:

Other slide
=========
```

It has the id "other-section". Thanks to this change the slides can be linked:

https://nekmo.github.io/django-rest-framework-presentacion/#/baterias-incluidas

And add custom css:
https://github.com/Nekmo/django-rest-framework-presentacion/blob/presentation/index.html#L100-L105
https://github.com/Nekmo/django-rest-framework-presentacion/blob/master/_static/theme.scss#L253-L258


