### PR TITLE
Handle section id as reveal.js internal link

### DIFF
--- a/docs/configurations.rst
+++ b/docs/configurations.rst
@@ -68,6 +68,17 @@ If you use ``revealjs_google_fonts``, set last of ``font-family`` style.
 Presentation Configurations
 ===========================
 
+revealjs_use_section_ids
+------------------------
+
+:Type: ``boolean``
+:Optional:
+:Default: ``False``
+
+If this is set ``True``,
+inject ``id`` attribute into ``section`` element (parent of headerings).
+This means that change format of internal links (default is numbering style).
+
 revealjs_script_files
 ---------------------
 

--- a/sphinx_revealjs/__init__.py
+++ b/sphinx_revealjs/__init__.py
@@ -47,6 +47,7 @@ def setup(app: Sphinx):
     app.add_directive("revealjs_section", RevealjsSection)
     app.add_directive("revealjs_slide", RevealjsSlide)
     app.add_directive("revealjs_fragments", RevealjsFragments)
+    app.add_config_value("revealjs_use_section_ids", False, True)
     app.add_config_value("revealjs_static_path", [], True)
     app.add_config_value("revealjs_style_theme", "black", True)
     app.add_config_value("revealjs_css_files", [], True)

--- a/sphinx_revealjs/writers.py
+++ b/sphinx_revealjs/writers.py
@@ -41,7 +41,7 @@ class RevealjsSlideTranslator(HTML5Translator):
             attrs = meta.attributes_str()
         else:
             attrs = ""
-        if node.attributes.get("ids"):
+        if node.attributes.get("ids") and self.config.revealjs_use_section_ids:
             attrs += ' id="{}"'.format(node.attributes["ids"][-1])
         if self.section_level == 1:
             self.builder.revealjs_slide = find_child_section(node, "revealjs_slide")

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -7,6 +7,12 @@ from testutils import gen_app_conf, soup_html
 
 
 class BuildHtmlTests(unittest.TestCase):  # noqa
+    @with_app(**gen_app_conf())
+    def test_defaults(self, app: TestApp, status, warning):  # noqa
+        soup = soup_html(app, "index.html")
+        for e in soup.find_all("section"):
+            self.assertNotIn("id", e.attrs)
+
     @with_app(**gen_app_conf(confoverrides={"revealjs_script_files": ["js/test.js"]}))
     def test_script_tags(self, app: TestApp, status, warning):  # noqa
         soup = soup_html(app, "index.html")
@@ -202,3 +208,17 @@ class BuildHtmlTests(unittest.TestCase):  # noqa
         )
         custom_css_index = stylesheet_href_list.index("_static/other_custom.css")
         self.assertTrue(specified_theme_index < custom_css_index)
+
+    @with_app(
+        **gen_app_conf(
+            confoverrides={
+                "revealjs_use_section_ids": True,
+            }
+        )
+    )
+    def test_inject_id_to_all_sections(self, app: TestApp, status, warning):  # noqa
+        soup = soup_html(app, "index.html")
+        for e in soup.find_all("section"):
+            children = set([c.name for c in e.children])
+            if children & {"h1", "h2", "h3"}:
+                self.assertIn("id", e.attrs)


### PR DESCRIPTION
This PR is to fix and update features about using ids as internal link.
(Base idea is #59 )

## Problems of currently implements

All internal links are used `id` labels forcefully.
User cannot use numbered links then lost back compatibility.

This feature must be provided as optional.

## Considerations

Are there users that want to mixed style links.

- Default is numbered links
- If label is exists, use string links for only this section 