### PR TITLE
Update reveal.js version ( to 4.1.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "reveal.js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-4.1.1.tgz",
-      "integrity": "sha512-Ol+/3LF4sZKQQOaG7/Jsa7t5Kix1I+dx9UEYL8mOOn2sWROtLcbI3AGHZbNQPWeuvnQ/y1R3MJ0vN9ZI5nBPUg=="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-4.1.3.tgz",
+      "integrity": "sha512-5VbL4nVDUedVKnOIIM3UQAIUlp+CvR/SrUkrN5GDoVfcWJAxH2oIh7PWyShy7+pE7tgkH2q+3e5EikGRpgE+oA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "private": true,
   "name": "sphinx-revealjs",
   "dependencies": {
-    "reveal.js": "4.1.1"
+    "reveal.js": "4.1.3"
   }
 }

--- a/tools/fetch_revealjs.py
+++ b/tools/fetch_revealjs.py
@@ -17,7 +17,7 @@ ROOT_DIR = Path(__file__).parent.parent.absolute()
 
 RULES = [
     {
-        "version": "4.1.1",
+        "version": "4.1.3",
         "src": ["dist", "plugin", "LICENSE"],
         "dest": "sphinx_revealjs/themes/sphinx_revealjs/static/revealjs4",
     }


### PR DESCRIPTION
For #67 .

But, fetch process does not work because there is not reveal.js v4.1.3 in GitHub releases.

Merge this PR after updated it.