### PR TITLE
Split `html_js_files` and `revealjs_js_files`

### DIFF
--- a/sphinx_revealjs/__init__.py
+++ b/sphinx_revealjs/__init__.py
@@ -47,8 +47,7 @@ def inherit_extension_nodes(app: Sphinx, config: Config):
 def setup(app: Sphinx):
     """Set up function called by Sphinx."""
     app.connect("config-inited", inherit_extension_nodes)
-    # After convert_html_js_files
-    app.connect("config-inited", convert_reveal_js_files, priority=810)
+    app.connect("config-inited", convert_reveal_js_files)
     app.add_builder(RevealjsHTMLBuilder)
     app.add_node(
         revealjs_section, html=(not_write, not_write), revealjs=(not_write, not_write)

--- a/sphinx_revealjs/builders.py
+++ b/sphinx_revealjs/builders.py
@@ -148,8 +148,4 @@ def convert_reveal_js_files(app: Sphinx, config: Config) -> None:
             except Exception:
                 logger.warning(__("invalid js_file: %r, ignored"), entry)
                 continue
-    # Use html_js_files for backward compatibility
-    if revealjs_js_files:
-        config.revealjs_js_files = revealjs_js_files  # type: ignore
-    else:
-        config.revealjs_js_files = config.html_js_files
+    config.revealjs_js_files = revealjs_js_files  # type: ignore

--- a/sphinx_revealjs/builders.py
+++ b/sphinx_revealjs/builders.py
@@ -62,6 +62,13 @@ class RevealjsHTMLBuilder(StandaloneHTMLBuilder):
         for filename in self.get_builder_config("css_files", "revealjs"):
             self.add_css_file(filename)
 
+    def init_js_files(self) -> None:  # noqa
+        for filename, attrs in self.app.registry.js_files:
+            self.add_js_file(filename, **attrs)
+
+        for filename, attrs in self.get_builder_config("js_files", "revealjs"):
+            self.add_js_file(filename, **attrs)
+
     def get_theme_config(self) -> Tuple[str, Dict]:
         """Find and return configuration about theme (name and option params).
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -207,6 +207,8 @@ def test_unuse_html_js_files(app, status, warning):  # noqa
         "script", src="https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.10.7/dayjs.min.js"
     )
     assert elm is None
+    assert soup.find("script", src="_static/jquery.js") is None
+    assert soup.find("script", src="_static/underscore.js") is None
 
 
 @pytest.mark.sphinx(

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -191,7 +191,7 @@ def test_revealjs_js_files(app, status, warning):  # noqa
     assert elm is not None
 
 
-# TODO: Unsupport 2.x
+# TODO: Unsupport 2.x (keep until 3.x)
 @pytest.mark.sphinx(
     "revealjs",
     testroot="misc",
@@ -201,33 +201,8 @@ def test_revealjs_js_files(app, status, warning):  # noqa
         ]
     },
 )
-def test_support_html_js_files(app, status, warning):  # noqa
+def test_unuse_html_js_files(app, status, warning):  # noqa
     soup = soup_html(app, "index.html")
-    elm = soup.find(
-        "script", src="https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.10.7/dayjs.min.js"
-    )
-    assert elm is not None
-
-
-# TODO: Unsupport 2.x
-@pytest.mark.sphinx(
-    "revealjs",
-    testroot="misc",
-    confoverrides={
-        "html_js_files": [
-            "https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.10.7/dayjs.min.js"
-        ],
-        "revealjs_js_files": [
-            "https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.10.6/dayjs.min.js"
-        ],
-    },
-)
-def test_priority_html_and_revealjs_js_files(app, status, warning):  # noqa
-    soup = soup_html(app, "index.html")
-    elm = soup.find(
-        "script", src="https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.10.6/dayjs.min.js"
-    )
-    assert elm is not None
     elm = soup.find(
         "script", src="https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.10.7/dayjs.min.js"
     )


### PR DESCRIPTION
## Targets

- Split `html_js_files` and `revealjs_js_files` to configure per any builders.
- Does not add js files that need not use as reveal.js (fix #25)