### PR TITLE
Update behavior of `revealjs_script_conf`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ New features
 ------------
 
 * Add ``revealjs_js_files`` for ``conf.py`` to set JS file. (#77)
+* ``revealjs_script_conf`` accepts dict types (#56)
 
 ver 1.3.1
 =========

--- a/demo/revealjs4/conf.py
+++ b/demo/revealjs4/conf.py
@@ -35,15 +35,13 @@ html_static_path = ["_static"]
 revealjs_static_path = ["_static"]
 revealjs_google_fonts = ["M PLUS 1p",]
 revealjs_style_theme = "black"
-revealjs_script_conf = """
-    {
-        controls: true,
-        progress: true,
-        history: true,
-        center: true,
-        transition: "slide",
-    }
-"""
+revealjs_script_conf = {
+    "controls": True,
+    "progress": True,
+    "history": True,
+    "center": True,
+    "transition": "slide",
+}
 revealjs_script_plugins = [
     {
         "name": "RevealNotes",

--- a/docs/configurations.rst
+++ b/docs/configurations.rst
@@ -117,15 +117,17 @@ Example:
 revealjs_script_conf
 --------------------
 
-:Type: ``str``
+:Type: ``str or dict``
 :Optional:
 :Default: ``None``
 
-Raw JavaScript code for configuration of Reveal.js.
+Configuration of Reveal.js presentation.
+This value is used as options of ``Reveal.initialize`` in output files.
 
-If this value is set, render ``script`` tag after source script tags.
+* If value is string type, handle as raw javascript code.
+* If value is dict object, convert to json string at internal.
 
-Example:
+Example 1: case of str
 
   .. code-block:: py
 
@@ -151,6 +153,31 @@ Example:
         });
         revealjs.initialize(revealjsConfig);
       </script>
+
+
+Example 2: case of dict
+
+  .. code-block:: py
+
+      revealjs_script_conf = {
+          "controls": False,
+          "transition": "zoom",
+      }
+
+  .. code-block:: html
+
+      <div>
+        <!-- Presentation body -->
+      </div>
+      <script src="_static/revealjs/js/revealjs.js"></script>
+      <!-- here!! -->
+      <script>
+        let revealjsConfig = {};
+        revealjsConfig = Object.assign(revealjsConfig, JSON.parse('{"controls": false, "transition": "zoom"}'));
+        revealjs.initialize(revealjsConfig);
+      </script>
+
+example 1 and 2 are behaving same.
 
 revealjs_script_plugins
 -----------------------

--- a/sphinx_revealjs/contexts.py
+++ b/sphinx_revealjs/contexts.py
@@ -1,5 +1,6 @@
 """Contexts for passing between objects."""
-from typing import List
+import json
+from typing import Dict, List, Union
 
 from .utils import static_resource_uri
 
@@ -74,11 +75,14 @@ class RevealjsProjectContext(object):
         self,
         engine_version: int,
         script_files: List[str] = None,
-        script_conf: str = None,
+        script_conf: Union[str, Dict] = None,
         script_plugins: List[RevealjsPlugin] = None,
     ):  # noqa
         self.engine = RevealjsEngine.from_version(engine_version)
-        self.script_conf = script_conf
+        if isinstance(script_conf, str):
+            self.script_conf = script_conf
+        else:
+            self.script_conf = f"JSON.parse('{json.dumps(script_conf)}')"
         self.script_plugins = script_plugins or []
         self._script_files = script_files or []
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -114,8 +114,9 @@ def test_revealjs_script_conf(app, status, warning):  # noqa
 )
 def test_revealjs_script_conf_as_dict(app, status, warning):  # noqa
     soup = soup_html(app, "index.html")
-    assert 'Object.assign(revealjsConfig, JSON.parse(\'{"transition": "none"}\'));' in str(
-        soup.find_all("script")[-1]
+    assert (
+        'Object.assign(revealjsConfig, JSON.parse(\'{"transition": "none"}\'));'
+        in str(soup.find_all("script")[-1])
     )
 
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -110,6 +110,18 @@ def test_revealjs_script_conf(app, status, warning):  # noqa
 @pytest.mark.sphinx(
     "revealjs",
     testroot="misc",
+    confoverrides={"revealjs_script_conf": {"transition": "none"}},
+)
+def test_revealjs_script_conf_as_dict(app, status, warning):  # noqa
+    soup = soup_html(app, "index.html")
+    assert 'Object.assign(revealjsConfig, JSON.parse(\'{"transition": "none"}\'));' in str(
+        soup.find_all("script")[-1]
+    )
+
+
+@pytest.mark.sphinx(
+    "revealjs",
+    testroot="misc",
     confoverrides={
         "revealjs_script_plugins": [
             {


### PR DESCRIPTION
Update about issue #56.

In version 1.x , `revealjs_script_conf` accepts `str` and `dict`(JSON serializable) types.