### PR TITLE
Fix typos in doc/configurations.rst

### DIFF
--- a/doc/configurations.rst
+++ b/doc/configurations.rst
@@ -160,8 +160,10 @@ Presentation Configurations
    .. code-block:: py
 
       revealjs_script_plugins = [
-          "src": "revealjs/plugin/highlight/highlight.js",
-          "name": "RevealHighlight",
+          {
+              "src": "revealjs4/plugin/highlight/highlight.js",
+              "name": "RevealHighlight",
+          },
       ]
 
    .. code-block:: html


### PR DESCRIPTION
I noticed some typos about `revealjs_script_plugins`.
Please merge this.