### PR TITLE
doc: fix double backquotes appearing on demo slide

### DIFF
--- a/demo/revealjs4/_locales/ja/LC_MESSAGES/main.po
+++ b/demo/revealjs4/_locales/ja/LC_MESSAGES/main.po
@@ -254,7 +254,7 @@ msgstr "コードブロックのアニメ表示"
 #: ../../_sections/interactive-content.rst:21
 #: ../../_sections/interactive-content.rst:31
 msgid "Enable animations for each `revealjs-section` and `revealjs-break`:"
-msgstr "``revealjs-section``や ``revealjs-break`` を用いてアニメーションの設定が可能です。"
+msgstr "``revealjs-section`` や ``revealjs-break`` を用いてアニメーションの設定が可能です。"
 
 #: ../../_sections/interactive-content.rst:40
 msgid "Fragments"


### PR DESCRIPTION
Thank you for all your awesome library.

I found double backquotes appearing on demo slide.
https://attakei.github.io/sphinx-revealjs/main-ja.html
![image](https://user-images.githubusercontent.com/21273221/195370682-b563c441-0ae6-47d3-889f-42f48cd1ae04.png)
So I send this pull request😃
But I am not experienced in Sphinx translation, so I may have changed the file improperly.

I noticed that English slide uses **single** backquote.
https://attakei.github.io/sphinx-revealjs/main-en.html
![image](https://user-images.githubusercontent.com/21273221/195371221-0fc60350-27d7-44b9-8490-215225b82b2b.png)
So maybe it should be as follows (single backquote version)

```
msgstr "`revealjs-section` や `revealjs-break` を用いてアニメーションの設定が可能です。"
```