### PR TITLE
Fix typo in conf.py for test data

### DIFF
--- a/tests/roots/test-default/conf.py
+++ b/tests/roots/test-default/conf.py
@@ -1,4 +1,4 @@
-"""This configuration is cases for efault behavior."""
+"""This configuration is cases for default behavior."""
 extensions = [
     "sphinx_revealjs",
 ]

--- a/tests/roots/test-for-commented-notes/conf.py
+++ b/tests/roots/test-for-commented-notes/conf.py
@@ -1,4 +1,4 @@
-"""This configuration is cases for efault behavior."""
+"""This configuration is cases for default behavior."""
 extensions = [
     "sphinx_revealjs",
 ]


### PR DESCRIPTION
The test code was very helpful in writing tests for the Sphinx extension.
Thank you very much!

I found a typo in conf.py so send this pull request.

"For-commented-notes" case may require modification of the docstring itself.
