### PR TITLE
Update reveal.js from v4.4.0 to null

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sphinx-revealjs",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -16,13 +16,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    }
-  },
-  "dependencies": {
-    "reveal.js": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-4.4.0.tgz",
-      "integrity": "sha512-jIV6C9V2NEUjGzU8L6dUFGpk1KJmq7/EzP2fOW67ggc2c0Cp/PdprWxZ9Qgp46F0T2ZWDCjQ1p3Ytzy5jA6a2w=="
     }
   }
 }


### PR DESCRIPTION
Please see [changelog of reveal.js](https://github.com/hakimel/reveal.js/releases/tag/null)

Auto-generated by GitHub Actions