### PR TITLE
Update reveal.js from v5.0.2 to 5.0.4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6,13 +6,13 @@
     "": {
       "name": "sphinx-revealjs",
       "dependencies": {
-        "reveal.js": "^5.0.2"
+        "reveal.js": "^5.0.4"
       }
     },
     "node_modules/reveal.js": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-5.0.2.tgz",
-      "integrity": "sha512-G5dhsr/2wormdrYPtZBfRamvnPrHc/8TtYVH3EpIzfMyKSiTprFwn61nFZbcmeK4iKKdLq2MMiiMNqlRmkBU4A==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-5.0.4.tgz",
+      "integrity": "sha512-480pVhre9SXWuE4QbDwG0nPrip3TkifflqaKQWF8Ynf4iYIUBfgu5leeMso0srubQsZQ+G2OzktAfAkrvBY0Ww==",
       "engines": {
         "node": ">=18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "private": true,
   "name": "sphinx-revealjs",
   "dependencies": {
-    "reveal.js": "^5.0.2"
+    "reveal.js": "^5.0.4"
   }
 }


### PR DESCRIPTION
Please see [changelog of reveal.js](https://github.com/hakimel/reveal.js/releases/tag/5.0.4)

Auto-generated by GitHub Actions