### PR TITLE
Render all nodes in parent heading by `revealjs-break`

### DIFF
--- a/sphinx_revealjs/writers.py
+++ b/sphinx_revealjs/writers.py
@@ -152,6 +152,7 @@ def depart_revealjs_break(self, node: revealjs_break):
     if "notitle" not in node.attributes:
         title = find_child_section(node.parent, "title")
         self.body.append(f"<h{self.section_level}>")
-        self.body.append(title.children[0])
+        for c in title.children:
+            c.walkabout(self)
         self.body.append(f"</h{self.section_level}>")
         self.body.append("\n")

--- a/sphinx_revealjs/writers.py
+++ b/sphinx_revealjs/writers.py
@@ -151,8 +151,6 @@ def depart_revealjs_break(self, node: revealjs_break):
     self.body.append(f"<section {attrs}>\n")
     if "notitle" not in node.attributes:
         title = find_child_section(node.parent, "title")
-        self.body.append(f"<h{self.section_level}>")
-        for c in title.children:
-            c.walkabout(self)
-        self.body.append(f"</h{self.section_level}>")
+        # NOTE: It has possibility to work side effect because re-walk for used nodes.
+        title.walkabout(self)
         self.body.append("\n")

--- a/tests/roots/test-default/with-revealjs-break-decorated.rst
+++ b/tests/roots/test-default/with-revealjs-break-decorated.rst
@@ -1,0 +1,15 @@
+=================
+Test presentation
+=================
+
+Sample
+======
+
+**Decorated** Head
+------------------
+
+content 1
+
+.. revealjs-break::
+
+content 2

--- a/tests/test_directives/test_break.py
+++ b/tests/test_directives/test_break.py
@@ -19,3 +19,10 @@ def test_top_of_section(app: SphinxTestApp, status, warning):  # noqa
     section_tag = soup.h1.parent.parent
     print(section_tag)
     assert len(section_tag.find_all("section")) == 2
+
+
+@pytest.mark.sphinx("revealjs", testroot="default")
+def test_render_all_items_of_head(app: SphinxTestApp, status, warning):  # noqa
+    soup = soup_html(app, "with-revealjs-break-decorated.html")
+    head = soup.find_all("h3")[-1]
+    assert head.text == "Decorated Head"


### PR DESCRIPTION
Refs: #167 