### PR TITLE
Fix/copy data background assets (2)

### DIFF
--- a/sphinx_revealjs/directives.py
+++ b/sphinx_revealjs/directives.py
@@ -1,6 +1,7 @@
 """Custom directives for Reveal.js."""
 
 import json
+from typing import Union, overload
 
 from docutils import nodes
 from docutils.nodes import Sequential  # type: ignore
@@ -84,7 +85,21 @@ REVEALJS_SECTION_ATTRIBUTES = {
 }
 
 
-def inject_children(node: revealjs_section) -> revealjs_section:
+@overload
+def inject_children(node: revealjs_section) -> revealjs_section: ...
+
+
+@overload
+def inject_children(node: revealjs_break) -> revealjs_break: ...
+
+
+@overload
+def inject_children(node: revealjs_vertical) -> revealjs_vertical: ...
+
+
+def inject_children(
+    node: Union[revealjs_section, revealjs_break, revealjs_vertical],
+) -> Union[revealjs_section, revealjs_break, revealjs_vertical]:
     """Inject extra nodes as children."""
 
     def _configure_local_image(node, uri):
@@ -110,7 +125,7 @@ class RevealjsVertical(Directive):  # noqa: D101
         node = revealjs_vertical()
         node.attributes.update(self.options)
         return [
-            node,
+            inject_children(node),
         ]
 
 
@@ -136,7 +151,7 @@ class RevealjsBreak(Directive):  # noqa: D101
         node = revealjs_break()
         node.attributes.update(self.options)
         return [
-            node,
+            inject_children(node),
         ]
 
 

--- a/sphinx_revealjs/writers.py
+++ b/sphinx_revealjs/writers.py
@@ -5,6 +5,7 @@ from typing import Union
 
 from docutils.nodes import (  # type: ignore
     Element,
+    SkipChildren,
     SkipNode,
     comment,
     image,
@@ -181,6 +182,7 @@ def skip_node(self, node):
 def visit_revealjs_break(self, node: revealjs_break):
     """Close current section."""
     self.body.append("</section>\n")
+    raise SkipChildren
 
 
 def depart_revealjs_break(self, node: revealjs_break):
@@ -189,7 +191,7 @@ def depart_revealjs_break(self, node: revealjs_break):
     If node does not have attribute 'notitle',
     render title from current original section.
     """
-    attrs = node.attributes_str()
+    attrs = build_attributes_str(node, self.builder)  # type: ignore[arg-type]
     self.body.append(f"<section {attrs}>\n")
     if "notitle" not in node.attributes:
         idx = node.parent.first_child_matching_class(title)

--- a/sphinx_revealjs/writers.py
+++ b/sphinx_revealjs/writers.py
@@ -87,7 +87,11 @@ class RevealjsSlideTranslator(HTML5Translator):
 
         if self._nest_step > 0:
             v_idx = node.first_child_matching_class(revealjs_vertical)
-            v_attrs = "" if v_idx is None else node.children[v_idx].attributes_str()  # type: ignore[attr-defined]
+            v_attrs = (
+                ""
+                if v_idx is None
+                else build_attributes_str(node.children[v_idx], self.builder)  # type: ignore[arg-type]
+            )
             self.body.append(f"<section {v_attrs}>\n")
         self.body.append(f"<section {attrs}>\n")
 

--- a/tests/roots/test-default/with-section-directives/with-break-background-iframe-local.rst
+++ b/tests/roots/test-default/with-section-directives/with-break-background-iframe-local.rst
@@ -1,0 +1,15 @@
+=================
+Test presentation
+=================
+
+Sample
+======
+
+Head
+----
+
+content
+
+.. revealjs-break::
+   :data-background-iframe: iframe/sample.html
+

--- a/tests/roots/test-default/with-section-directives/with-vertical-background-iframe-local.rst
+++ b/tests/roots/test-default/with-section-directives/with-vertical-background-iframe-local.rst
@@ -1,0 +1,14 @@
+=================
+Test presentation
+=================
+
+Sample
+======
+
+.. revealjs-vertical::
+   :data-background-iframe: iframe/sample.html
+
+Head
+----
+
+content

--- a/tests/test_directives/test_section.py
+++ b/tests/test_directives/test_section.py
@@ -118,6 +118,17 @@ def test_render_local_iframe_localfile_from_vertical(app: SphinxTestApp):  # noq
 
 
 @pytest.mark.sphinx("revealjs", testroot="default")
+def test_render_local_iframe_localfile_from_break(app: SphinxTestApp):  # noqa
+    soup = soup_html(
+        app, "with-section-directives/with-break-background-iframe-local.html"
+    )
+    assert (Path(app.outdir) / "_images/sample.html").exists()
+    section_tag = soup.h2.parent.parent.find_all("section")[-1]
+    assert "data-background-iframe" in section_tag.attrs
+    assert section_tag["data-background-iframe"] == "../_images/sample.html"
+
+
+@pytest.mark.sphinx("revealjs", testroot="default")
 def test_render_local_iframe(app: SphinxTestApp):  # noqa
     soup = soup_html(app, "with-section-directives/with-background-iframe.html")
     section_tag = soup.h2.parent

--- a/tests/test_directives/test_section.py
+++ b/tests/test_directives/test_section.py
@@ -107,6 +107,17 @@ def test_render_local_iframe_localfile(app: SphinxTestApp):  # noqa
 
 
 @pytest.mark.sphinx("revealjs", testroot="default")
+def test_render_local_iframe_localfile_from_vertical(app: SphinxTestApp):  # noqa
+    soup = soup_html(
+        app, "with-section-directives/with-vertical-background-iframe-local.html"
+    )
+    assert (Path(app.outdir) / "_images/sample.html").exists()
+    section_tag = soup.h2.parent.parent
+    assert "data-background-iframe" in section_tag.attrs
+    assert section_tag["data-background-iframe"] == "../_images/sample.html"
+
+
+@pytest.mark.sphinx("revealjs", testroot="default")
 def test_render_local_iframe(app: SphinxTestApp):  # noqa
     soup = soup_html(app, "with-section-directives/with-background-iframe.html")
     section_tag = soup.h2.parent


### PR DESCRIPTION
This fixes include `revealjs_vertical` and `revealjs_break`.

Refs: #184