### PR TITLE
Define new sub-extension to compile sass/scss

### DIFF
--- a/demo/_static/.gitignore
+++ b/demo/_static/.gitignore
@@ -1,1 +1,2 @@
-css/
+*.css
+*.css.map

--- a/demo/conf.py
+++ b/demo/conf.py
@@ -20,7 +20,6 @@ extensions = [
     "sphinx.ext.todo",
     # My extensions
     "atsphinx.mini18n",
-    "atsphinx.toybox.sass",
     "oembedpy.adapters.sphinx",
     "rst_package_refs.sphinx",
     "sphinxcontrib.budoux",
@@ -30,6 +29,7 @@ extensions = [
     # This project
     "sphinx_revealjs",
     "sphinx_revealjs.ext.footnotes",
+    "sphinx_revealjs.ext.sass",
     "sphinx_revealjs.ext.screenshot",
 ]
 templates_path = ["_templates"]
@@ -47,7 +47,7 @@ html_static_path = ["_static"]
 # -- Options for Reveal.js output ---------------------------------------------
 revealjs_html_theme = "revealjs-simple"
 revealjs_static_path = ["_static"]
-revealjs_style_theme = "css/custom.css"
+revealjs_style_theme = "custom.css"
 revealjs_script_conf = {
     "controls": True,
     "progress": True,
@@ -109,10 +109,14 @@ ogp_custom_meta_tags = [
 mini18n_default_language = "en"
 mini18n_support_languages = ["en", "ja"]
 mini18n_basepath = "/sphinx-revealjs/"
-# - atsphinx.toybox.sass
-sass_load_paths = [
+# - sphinx_revealjs.ext.sass
+sass_src_dir = "_sass"
+sass_out_dir = "_static"
+sass_targets = {}
+sass_include_paths = [
     get_revealjs_path() / "css" / "theme",
 ]
+sass_auto_targets = True
 
 
 def update_ogp(app, config):

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,6 +16,7 @@ release = __version__
 extensions = [
     "atsphinx.footnotes",
     "atsphinx.htmx_boost",
+    "rst_package_refs.sphinx",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",

--- a/doc/optional-extensions/sass.rst
+++ b/doc/optional-extensions/sass.rst
@@ -1,0 +1,95 @@
+========================
+sphinx_revealjs.ext.sass
+========================
+
+.. versionadded:: 3.2.0
+
+Overview
+========
+
+This extension compile Sass/SCSS source into CSS files using Dart Sass.
+This is same feature of :pypi:`sphinxcontrib-sass`,
+but it includes tuning for ``sphinx-revealjs``.
+
+Installation
+============
+
+You need not install extra, you can use it immediately after installing |THIS|.
+
+Usage
+=====
+
+Add extension module into ``extensions`` of your ``conf.py``.
+
+.. code-block:: python
+   :caption: conf.py
+
+   extensions = [
+       "sphinx_revealjs",
+       "sphinx_revealjs.ext.sass",
+   ]
+
+Configuration
+=============
+
+All Configuration names are prefixed ``revealjs_sass_``.
+
+.. confval:: revealjs_sass_src_dir
+
+   :Type: ``str``
+   :Default: ``None``
+   :Example: ``"_static"``
+
+   Root directory of source files fo ``revealjs_sass_targets`` and ``revealjs_sass_auto_targets``.
+
+.. confval:: revealjs_sass_out_dir
+
+   :Type: ``str``
+   :Default: ``None``
+   :Example: ``"_static"``
+
+   Root directory of destination fo ``revealjs_sass_targets`` and ``revealjs_sass_auto_targets``.
+
+.. confval:: revealjs_sass_targets
+
+   :Type: ``dict[str, str]``
+   :Default: ``{}`` (empty dict)
+   :Example: ``{"style.scss": "style.css"}``
+
+   Dict of targets to compile.
+
+   - Dict key is target filepath.
+   - Dict value is destination filepath.
+
+.. confval:: revealjs_sass_include_paths
+
+   :Type: ``list[str|Path]``
+   :Default: ``[]`` (empty list)
+   :Example: ``["_sass/modules"]``
+
+   List of paths to load as external module.
+
+   You need not to append revaljs theme resources because it is added automately in internal proccess.
+
+.. confval:: revealjs_sass_output_style
+
+   :Type: ``str``
+   :Default: ``"expanded"``
+   :Example: ``"compressed"``
+
+   Style of generated CSS files. You can select one of ``expanded`` or ``compressed``.
+
+   - ``expanded`` : Default style
+   - ``compressed`` : Minified style
+
+.. confval:: revealjs_sass_auto_targets
+
+   :Type: ``bool``
+   :Default: ``False``
+   :Example: ``True``
+
+   When it is set ``True``, extension works for all files matched these conditions
+
+   - Managed files on ``revealjs_sass_src_dir``.
+   - Files having extension either ``.sass`` or ``.scss``.
+   - File name do not begin underscore.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,10 @@ test = [
 doc = [
     "sphinx-autobuild ==2021.3.14",
     "sphinx-intl>=2.3.1",
-    "sphinx-rtd-theme >=0.5.1,<0.6",
+    "sphinx-rtd-theme",
     "atsphinx-footnotes",
     "atsphinx-htmx-boost",
+    "rst-package-refs>=0.1.0",
 ]
 demo = [
     "atsphinx-mini18n >=0.3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dev = [
     "mypy>=1.15.0",
     "esbonio>=0.16.5",
     "types-docutils>=0.21.0.20241128",
+    "types-requests>=2.32.0.20250306",
 ]
 test = [
     "BeautifulSoup4",

--- a/sphinx_revealjs/ext/sass/.gitignore
+++ b/sphinx_revealjs/ext/sass/.gitignore
@@ -1,0 +1,1 @@
+dart-sass

--- a/sphinx_revealjs/ext/sass/__init__.py
+++ b/sphinx_revealjs/ext/sass/__init__.py
@@ -46,7 +46,10 @@ def build_sass_sources(app: Sphinx, env: BuildEnvironment):
     src_dir = configure_path(app.confdir, app.config.sass_src_dir)
     out_dir = configure_path(app.confdir, app.config.sass_out_dir)
 
-    options = [f"--style={app.config.sass_output_style}"]
+    options = [
+        f"--style={app.config.sass_output_style}",
+        app.config.sass_build_warnings,
+    ]
     if app.config.sass_include_paths:
         options += [f"--load-path={p}" for p in app.config.sass_include_paths]
 
@@ -73,4 +76,5 @@ def setup(app: Sphinx):
     app.add_config_value("sass_targets", {}, "html")
     app.add_config_value("sass_output_style", "expanded", "html")
     app.add_config_value("sass_auto_targets", False, "html")
+    app.add_config_value("sass_build_warnings", "-q", "env")
     app.connect("env-updated", build_sass_sources)

--- a/sphinx_revealjs/ext/sass/__init__.py
+++ b/sphinx_revealjs/ext/sass/__init__.py
@@ -1,0 +1,12 @@
+"""SASS compile bridge."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
+
+
+def setup(app: Sphinx):
+    pass

--- a/sphinx_revealjs/ext/sass/__init__.py
+++ b/sphinx_revealjs/ext/sass/__init__.py
@@ -1,12 +1,67 @@
-"""SASS compile bridge."""
+"""SASS compile bridge.
+
+Some features of this are copied from https://github.com/attakei-lab/sphinxcontrib-sass/blob/main/sphinxcontrib/sass.py
+"""
 
 from __future__ import annotations
 
+import subprocess
+from os import PathLike
+from pathlib import Path
 from typing import TYPE_CHECKING
 
+from sphinx.util import logging
+
+from .dart_sass import setup_dart_sass
+
 if TYPE_CHECKING:
+    from typing import Optional, Union
+
     from sphinx.application import Sphinx
+    from sphinx.environment import BuildEnvironment
+
+SUB_ROOT = Path(__file__).parent
+
+Targets = dict[PathLike, PathLike]
+
+
+logger = logging.getLogger(__name__)
+
+
+def configure_path(conf_dir: PathLike, src: Optional[Union[PathLike, Path]]) -> Path:
+    if src is None:
+        target = Path(conf_dir)
+    elif isinstance(src, Path):
+        target = src
+    else:
+        target = Path(src)
+    if not target.is_absolute():
+        target = Path(conf_dir) / target
+    return target
+
+
+def build_sass_sources(app: Sphinx, env: BuildEnvironment):
+    sass_bin = setup_dart_sass("1.86.0", SUB_ROOT)
+    logger.debug("Building stylesheet files")
+    src_dir = configure_path(app.confdir, app.config.sass_src_dir)
+    out_dir = configure_path(app.confdir, app.config.sass_out_dir)
+    targets: Targets = app.config.sass_targets
+
+    options = [f"--style={app.config.sass_output_style}"]
+    if app.config.sass_include_paths:
+        options += [f"--load-path={p}" for p in app.config.sass_include_paths]
+
+    for src, dst in targets.items():
+        src_ = src_dir / src
+        out_path = out_dir / dst
+        out_path.parent.mkdir(exist_ok=True, parents=True)
+        subprocess.run([str(sass_bin), *options, f"{src_}:{out_path}"])
 
 
 def setup(app: Sphinx):
-    pass
+    app.add_config_value("sass_include_paths", [], "html")
+    app.add_config_value("sass_src_dir", None, "html")
+    app.add_config_value("sass_out_dir", None, "html")
+    app.add_config_value("sass_targets", {}, "html")
+    app.add_config_value("sass_output_style", "expanded", "html")
+    app.connect("env-updated", build_sass_sources)

--- a/sphinx_revealjs/ext/sass/__init__.py
+++ b/sphinx_revealjs/ext/sass/__init__.py
@@ -45,11 +45,19 @@ def build_sass_sources(app: Sphinx, env: BuildEnvironment):
     logger.debug("Building stylesheet files")
     src_dir = configure_path(app.confdir, app.config.sass_src_dir)
     out_dir = configure_path(app.confdir, app.config.sass_out_dir)
-    targets: Targets = app.config.sass_targets
 
     options = [f"--style={app.config.sass_output_style}"]
     if app.config.sass_include_paths:
         options += [f"--load-path={p}" for p in app.config.sass_include_paths]
+
+    targets: Targets = app.config.sass_targets
+    if app.config.sass_auto_targets:
+        for s in src_dir.glob("*.s[ac]ss"):
+            if s.name.startswith("_"):
+                continue
+            rel_src = s.relative_to(src_dir)
+            rel_dst = rel_src.parent / f"{rel_src.stem}.css"
+            targets[rel_src] = rel_dst
 
     for src, dst in targets.items():
         src_ = src_dir / src
@@ -64,4 +72,5 @@ def setup(app: Sphinx):
     app.add_config_value("sass_out_dir", None, "html")
     app.add_config_value("sass_targets", {}, "html")
     app.add_config_value("sass_output_style", "expanded", "html")
+    app.add_config_value("sass_auto_targets", False, "html")
     app.connect("env-updated", build_sass_sources)

--- a/sphinx_revealjs/ext/sass/__init__.py
+++ b/sphinx_revealjs/ext/sass/__init__.py
@@ -43,18 +43,18 @@ def configure_path(conf_dir: PathLike, src: Optional[Union[PathLike, Path]]) -> 
 def build_sass_sources(app: Sphinx, env: BuildEnvironment):
     sass_bin = setup_dart_sass("1.86.0", SUB_ROOT)
     logger.debug("Building stylesheet files")
-    src_dir = configure_path(app.confdir, app.config.sass_src_dir)
-    out_dir = configure_path(app.confdir, app.config.sass_out_dir)
+    src_dir = configure_path(app.confdir, app.config.revealjs_sass_src_dir)
+    out_dir = configure_path(app.confdir, app.config.revealjs_sass_out_dir)
 
     options = [
-        f"--style={app.config.sass_output_style}",
-        app.config.sass_build_warnings,
+        f"--style={app.config.revealjs_sass_output_style}",
+        app.config.revealjs_sass_build_warnings,
     ]
-    if app.config.sass_include_paths:
-        options += [f"--load-path={p}" for p in app.config.sass_include_paths]
+    if app.config.revealjs_sass_include_paths:
+        options += [f"--load-path={p}" for p in app.config.revealjs_sass_include_paths]
 
-    targets: Targets = app.config.sass_targets
-    if app.config.sass_auto_targets:
+    targets: Targets = app.config.revealjs_sass_targets
+    if app.config.revealjs_sass_auto_targets:
         for s in src_dir.glob("*.s[ac]ss"):
             if s.name.startswith("_"):
                 continue
@@ -70,11 +70,11 @@ def build_sass_sources(app: Sphinx, env: BuildEnvironment):
 
 
 def setup(app: Sphinx):
-    app.add_config_value("sass_include_paths", [], "html")
-    app.add_config_value("sass_src_dir", None, "html")
-    app.add_config_value("sass_out_dir", None, "html")
-    app.add_config_value("sass_targets", {}, "html")
-    app.add_config_value("sass_output_style", "expanded", "html")
-    app.add_config_value("sass_auto_targets", False, "html")
-    app.add_config_value("sass_build_warnings", "-q", "env")
+    app.add_config_value("revealjs_sass_include_paths", [], "html")
+    app.add_config_value("revealjs_sass_src_dir", None, "html")
+    app.add_config_value("revealjs_sass_out_dir", None, "html")
+    app.add_config_value("revealjs_sass_targets", {}, "html")
+    app.add_config_value("revealjs_sass_output_style", "expanded", "html")
+    app.add_config_value("revealjs_sass_auto_targets", False, "html")
+    app.add_config_value("revealjs_sass_build_warnings", "-q", "env")
     app.connect("env-updated", build_sass_sources)

--- a/sphinx_revealjs/ext/sass/dart_sass.py
+++ b/sphinx_revealjs/ext/sass/dart_sass.py
@@ -1,0 +1,102 @@
+"""dart-sass resolver.
+
+This is copy from https://github.com/atsphinx/toybox/blob/main/src/atsphinx/toybox/sass/dart_sass.py
+"""
+
+import platform
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import httpx
+from sphinx.util import logging
+
+OS_NAME = Literal["android", "linux", "macos", "windows"]
+ARCH_NAME = Literal[
+    "arm",
+    "arm-musl",
+    "arm64",
+    "arm64-musl",
+    "ia32",
+    "ia32-musl",
+    "riscv64",
+    "riscv64-musl",
+    "x64",
+    "x64-musl",
+]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Release:
+    """Release base information for GitHub."""
+
+    os: OS_NAME
+    arch: ARCH_NAME
+    version: str
+
+    @classmethod
+    def from_platform(cls, version: str) -> "Release":
+        """Create object from runtime information."""
+        os_name = resolve_os()
+        arch_name = resolve_arch()
+        return cls(os=os_name, arch=arch_name, version=version)
+
+    @property
+    def archive_url(self) -> str:
+        """Retrieve URL for archive of GitHub Releases."""
+        return f"https://github.com/sass/dart-sass/releases/download/{self.version}/dart-sass-{self.version}-{self.os}-{self.arch}.{self.archive_ext}"
+
+    @property
+    def archive_format(self) -> str:
+        """String of ``shutil.unpack_archive``."""
+        return "zip" if self.os == "windows" else "gztar"
+
+    @property
+    def archive_ext(self) -> str:
+        """File format as extension."""
+        return "zip" if self.os == "windows" else "tar.gz"
+
+    @property
+    def exec_ext(self) -> str:
+        """Extension of executable file."""
+        return ".bat" if self.os == "windows" else ""
+
+
+def resolve_os() -> OS_NAME:
+    """Retrieve os name as dart-sass specified."""
+    os_name = platform.system()
+    if os_name == "Darwin":
+        return "macos"
+    if os_name in ("Linux", "Windows", "Android"):
+        return os_name.lower()  # type: ignore[return-value]
+    raise Exception(f"There is not dart-sass binary for {os_name}")
+
+
+def resolve_arch() -> ARCH_NAME:
+    """Retrieve cpu architecture string as dart-sass specified."""
+    # NOTE: This logic is not all covered.
+    arch_name = platform.machine()
+    if arch_name in ("x86_64", "AMD64"):
+        arch_name = "x64"
+    if arch_name.startswith("arm") and arch_name != "arm64":
+        arch_name = "arm"
+    libc = platform.libc_ver()
+    arch_suffix = "-musi" if "musl" in libc[0] else ""
+    return f"{arch_name}{arch_suffix}"  # type: ignore[return-value]
+
+
+def setup_dart_sass(version: str, dist: Path) -> Path:
+    """If executable is not exists, download archive."""
+    release = Release.from_platform(version)
+    fullpath = dist / "dart-sass" / f"sass{release.exec_ext}"
+    if not fullpath.exists():
+        logger.debug(f"Binary archive is {release.archive_url}")
+        resp = httpx.get(release.archive_url, follow_redirects=True)
+        archive_path = Path(tempfile.mktemp())
+        archive_path.write_bytes(resp.content)
+        shutil.unpack_archive(archive_path, dist, release.archive_format)
+    return fullpath

--- a/sphinx_revealjs/ext/sass/dart_sass.py
+++ b/sphinx_revealjs/ext/sass/dart_sass.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-import httpx
+import requests
 from sphinx.util import logging
 
 OS_NAME = Literal["android", "linux", "macos", "windows"]
@@ -95,7 +95,7 @@ def setup_dart_sass(version: str, dist: Path) -> Path:
     fullpath = dist / "dart-sass" / f"sass{release.exec_ext}"
     if not fullpath.exists():
         logger.debug(f"Binary archive is {release.archive_url}")
-        resp = httpx.get(release.archive_url, follow_redirects=True)
+        resp = requests.get(release.archive_url, allow_redirects=True)
         archive_path = Path(tempfile.mktemp())
         archive_path.write_bytes(resp.content)
         shutil.unpack_archive(archive_path, dist, release.archive_format)

--- a/tests/roots/test-sass/_static/style.scss
+++ b/tests/roots/test-sass/_static/style.scss
@@ -1,0 +1,3 @@
+body {
+  display: block;
+}

--- a/tests/roots/test-sass/_static/style2.scss
+++ b/tests/roots/test-sass/_static/style2.scss
@@ -1,0 +1,3 @@
+body {
+  display: block;
+}

--- a/tests/roots/test-sass/conf.py
+++ b/tests/roots/test-sass/conf.py
@@ -11,5 +11,5 @@ rst_prolog = """
 """
 
 revealjs_static_path = ["_static"]
-sass_src_dir = "_static"
-sass_out_dir = "_static"
+revealjs_sass_src_dir = "_static"
+revealjs_sass_out_dir = "_static"

--- a/tests/roots/test-sass/conf.py
+++ b/tests/roots/test-sass/conf.py
@@ -1,0 +1,15 @@
+"""Configuration is cases for default behavior."""
+
+extensions = [
+    "sphinx_revealjs",
+    "sphinx_revealjs.ext.sass",
+]
+
+# To skip toctree
+rst_prolog = """
+:orphan:
+"""
+
+revealjs_static_path = ["_static"]
+sass_src_dir = "_static"
+sass_out_dir = "_static"

--- a/tests/roots/test-sass/index.rst
+++ b/tests/roots/test-sass/index.rst
@@ -1,0 +1,16 @@
+=================
+Test presentation
+=================
+
+Section 1
+=========
+
+Sub 1-1
+-------
+
+First content
+
+Sub 1-2
+-------
+
+Second content

--- a/tests/test_extensions/test_sass.py
+++ b/tests/test_extensions/test_sass.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from sphinx.testing.util import SphinxTestApp
+
+
+@pytest.mark.sphinx(
+    "revealjs",
+    testroot="sass",
+    confoverrides={
+        "sass_targets": {"style.scss": "style.css"},
+    },
+)
+def test_sass_simple_build(app: SphinxTestApp):
+    app.build()
+    assert (app.outdir / "_static" / "style.css").exists()
+
+
+@pytest.mark.sphinx(
+    "revealjs",
+    testroot="sass",
+    confoverrides={
+        "sass_auto_targets": True,
+    },
+)
+def test_sass_auto_build(app: SphinxTestApp):
+    app.build()
+    assert (app.outdir / "_static" / "style2.css").exists()

--- a/tests/test_extensions/test_sass.py
+++ b/tests/test_extensions/test_sass.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     "revealjs",
     testroot="sass",
     confoverrides={
-        "sass_targets": {"style.scss": "style.css"},
+        "revealjs_sass_targets": {"style.scss": "style.css"},
     },
 )
 def test_sass_simple_build(app: SphinxTestApp):
@@ -24,7 +24,7 @@ def test_sass_simple_build(app: SphinxTestApp):
     "revealjs",
     testroot="sass",
     confoverrides={
-        "sass_auto_targets": True,
+        "revealjs_sass_auto_targets": True,
     },
 )
 def test_sass_auto_build(app: SphinxTestApp):

--- a/uv.lock
+++ b/uv.lock
@@ -1359,6 +1359,7 @@ dev = [
     { name = "pillow" },
     { name = "pytest" },
     { name = "python-magic" },
+    { name = "rst-package-refs" },
     { name = "ruff" },
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, extra = ["test"], marker = "python_full_version < '3.10'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, extra = ["test"], marker = "python_full_version == '3.10.*'" },
@@ -1372,6 +1373,7 @@ dev = [
 doc = [
     { name = "atsphinx-footnotes" },
     { name = "atsphinx-htmx-boost" },
+    { name = "rst-package-refs" },
     { name = "sphinx-autobuild" },
     { name = "sphinx-intl" },
     { name = "sphinx-rtd-theme" },
@@ -1416,20 +1418,22 @@ dev = [
     { name = "pillow" },
     { name = "pytest" },
     { name = "python-magic" },
+    { name = "rst-package-refs", specifier = ">=0.1.0" },
     { name = "ruff", specifier = ">=0.9.6" },
     { name = "sphinx", extras = ["test"], specifier = ">=4.0" },
     { name = "sphinx-autobuild", specifier = "==2021.3.14" },
     { name = "sphinx-intl", specifier = ">=2.3.1" },
-    { name = "sphinx-rtd-theme", specifier = ">=0.5.1,<0.6" },
+    { name = "sphinx-rtd-theme" },
     { name = "types-docutils", specifier = ">=0.21.0.20241128" },
     { name = "types-requests", specifier = ">=2.32.0.20250306" },
 ]
 doc = [
     { name = "atsphinx-footnotes" },
     { name = "atsphinx-htmx-boost" },
+    { name = "rst-package-refs", specifier = ">=0.1.0" },
     { name = "sphinx-autobuild", specifier = "==2021.3.14" },
     { name = "sphinx-intl", specifier = ">=2.3.1" },
-    { name = "sphinx-rtd-theme", specifier = ">=0.5.1,<0.6" },
+    { name = "sphinx-rtd-theme" },
 ]
 test = [
     { name = "beautifulsoup4" },
@@ -1441,16 +1445,18 @@ test = [
 
 [[package]]
 name = "sphinx-rtd-theme"
-version = "0.5.1"
+version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "docutils" },
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-jquery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/e5/0d55470572e0a0934c600c4cda0c98209883aaeb45ff6bfbadcda7006255/sphinx_rtd_theme-0.5.1.tar.gz", hash = "sha256:eda689eda0c7301a80cf122dad28b1861e5605cbf455558f3775e1e8200e83a5", size = 2774928 }
+sdist = { url = "https://files.pythonhosted.org/packages/91/44/c97faec644d29a5ceddd3020ae2edffa69e7d00054a8c7a6021e82f20335/sphinx_rtd_theme-3.0.2.tar.gz", hash = "sha256:b7457bc25dda723b20b086a670b9953c859eab60a2a03ee8eb2bb23e176e5f85", size = 7620463 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/81/d5af3a50a45ee4311ac2dac5b599d69f68388401c7a4ca902e0e450a9f94/sphinx_rtd_theme-0.5.1-py2.py3-none-any.whl", hash = "sha256:fa6bebd5ab9a73da8e102509a86f3fcc36dec04a0b52ea80e5a033b2aba00113", size = 2793140 },
+    { url = "https://files.pythonhosted.org/packages/85/77/46e3bac77b82b4df5bb5b61f2de98637724f246b4966cfc34bc5895d852a/sphinx_rtd_theme-3.0.2-py2.py3-none-any.whl", hash = "sha256:422ccc750c3a3a311de4ae327e82affdaf59eb695ba4936538552f3b00f4ee13", size = 7655561 },
 ]
 
 [[package]]
@@ -1505,6 +1511,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705 },
+]
+
+[[package]]
+name = "sphinxcontrib-jquery"
+version = "4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/f3/aa67467e051df70a6330fe7770894b3e4f09436dea6881ae0b4f3d87cad8/sphinxcontrib-jquery-4.1.tar.gz", hash = "sha256:1620739f04e36a2c779f1a131a2dfd49b2fd07351bf1968ced074365933abc7a", size = 122331 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/85/749bd22d1a68db7291c89e2ebca53f4306c3f205853cf31e9de279034c3c/sphinxcontrib_jquery-4.1-py2.py3-none-any.whl", hash = "sha256:f936030d7d0147dd026a4f2b5a57343d233f1fc7b363f68b3d4f1cb0993878ae", size = 121104 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1367,6 +1367,7 @@ dev = [
     { name = "sphinx-intl" },
     { name = "sphinx-rtd-theme" },
     { name = "types-docutils" },
+    { name = "types-requests" },
 ]
 doc = [
     { name = "atsphinx-footnotes" },
@@ -1421,6 +1422,7 @@ dev = [
     { name = "sphinx-intl", specifier = ">=2.3.1" },
     { name = "sphinx-rtd-theme", specifier = ">=0.5.1,<0.6" },
     { name = "types-docutils", specifier = ">=0.21.0.20241128" },
+    { name = "types-requests", specifier = ">=2.32.0.20250306" },
 ]
 doc = [
     { name = "atsphinx-footnotes" },
@@ -1622,6 +1624,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/dd/df/64e7ab01a4fc5ce46895dc94e31cffc8b8087c8d91ee54c45ac2d8d82445/types_docutils-0.21.0.20241128.tar.gz", hash = "sha256:4dd059805b83ac6ec5a223699195c4e9eeb0446a4f7f2aeff1759a4a7cc17473", size = 26739 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/b6/10ba95739f2cbb9c5bd2f6568148d62b468afe01a94c633e8892a2936d8a/types_docutils-0.21.0.20241128-py3-none-any.whl", hash = "sha256:e0409204009639e9b0bf4521eeabe58b5e574ce9c0db08421c2ac26c32be0039", size = 34677 },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.32.0.20250306"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/1a/beaeff79ef9efd186566ba5f0d95b44ae21f6d31e9413bcfbef3489b6ae3/types_requests-2.32.0.20250306.tar.gz", hash = "sha256:0962352694ec5b2f95fda877ee60a159abdf84a0fc6fdace599f20acb41a03d1", size = 23012 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/26/645d89f56004aa0ba3b96fec27793e3c7e62b40982ee069e52568922b6db/types_requests-2.32.0.20250306-py3-none-any.whl", hash = "sha256:25f2cbb5c8710b2022f8bbee7b2b66f319ef14aeea2f35d80f18c9dbf3b60a0b", size = 20673 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Overview

This PR is to create optional extension `sphinx_revealjs.ext.sass` that compile scss/sass for Revealjs theme.

## Motivation

Reveal.js 5.2.0 uses [`sass:color`](https://sass-lang.com/documentation/modules/color/) module in theme,
but libsass [^1] is not supported.
Therefore, it should use dart-sass to compile custom theme.

Currently:

- [dart-sass](https://pypi.org/project/dart-sass/) is published on PyPI, but it is old and stopped maintenance.
- I managed [atsphinx-toybox](https://pypi.org/project/atsphinx-toybox/) that includes sass extension, but it has too many features to use sass.

## Goal

New optional extension will provide sass compiler optimized revealjs themes.

- Set theme sass directory into loading paths in default.
- Keep compatibility parameters for `sphinxcontrib-sass` (for users included me).

## To do works

- [x] Copy config values from `sphinxcontrib-sass`.
- [x] Copy dart-sass using implements from `atsphinx-toybox`.
- [x] Migrate conf of demo to use this.
- [x] Write document.

[^1]: sphinxcontrib-sass uses libsass.