### PR TITLE
feat(highlightjs): Add script_appended_files to run scripts after loading highlight.js

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,30 @@
+ver 3.2.1
+=========
+
+:Release date: 2025-10-01 (Europe/Vienna)
+:Reveal.js version: 5.2.1
+
+Breaking changes
+----------------
+
+(CSS compilation using libsass does not work, but it is not core feature.
+Therefore, it is not included as breaking-change)
+
+Features
+--------
+
+* New configuration option ``revealjs_script_appended_files``.
+
+Fixes
+-----
+
+* Only define ``revealjsConfig`` when it is not yet defined.
+
+Others
+------
+
+* Added guide for including language packages and custom registration in RevealHighlight.
+
 ver 3.2.0
 =========
 

--- a/doc/configurations.rst
+++ b/doc/configurations.rst
@@ -89,7 +89,7 @@ Presentation Configurations
    :Default: ``[]``
    :Example: ``["presentation.js"]``
 
-   List of sources that render as ``script`` tags.
+   List of sources that render as ``script`` tags before the plugin scripts.
 
    There is bundled Reveal.js script at ``revealjs/js/reveal.js``.
 
@@ -103,6 +103,14 @@ Presentation Configurations
       <!-- here!! -->
       <script src="_static/revealjs/js/revealjs.js"></script>
       <script src="_static/presentation.js"></script>
+
+.. confval:: revealjs_script_appended_files
+
+   :Type: ``List[str]``
+   :Default: ``[]``
+   :Example: ``["presentation.js"]``
+
+   Same as ``revealjs_script_files``, but for scripts loaded after the plugin scripts.
 
 .. confval:: revealjs_script_conf
 

--- a/doc/tips/include-highlightjs-packages.rst
+++ b/doc/tips/include-highlightjs-packages.rst
@@ -1,0 +1,48 @@
+=========================================
+Including Highlight.js Language Packages
+=========================================
+
+Some languages listed with a "package" in the `Highlight.js supported languages table <https://highlightjs.readthedocs.io/en/latest/supported-languages.html>`_ are **not** included by default in Highlight.js or the RevealHighlight plugin. To use these languages, follow these steps:
+
+1. Prepare the Language Definition
+----------------------------------
+Download or copy the language definition file. Remove the ``hljs.registerLanguage`` function call, so it only defines the language, e.g.::
+
+    window.hljsDefineIecst = (() => {
+        "use strict";
+        return e => ({
+            // ...language definition...
+        });
+    })();
+
+1. Include the Language Definition
+----------------------------------
+Add the language definition file to your Sphinx config using the ``revealjs_script_files`` option::
+
+    revealjs_script_files = [
+        "revealjs/plugin/highlight/iecst.min.js",
+    ]
+
+1. Register the Language After Highlight.js Loads
+-------------------------------------------------
+Create a second JavaScript file (e.g. ``register-iecst.js``) to register the language after Highlight.js and RevealHighlight have loaded::
+
+    if (typeof revealjsConfig === 'undefined') { var revealjsConfig = new Object(); }
+    revealjsConfig.highlight = {
+        beforeHighlight: function (hljs) {
+            hljs.registerLanguage('iecst', window.hljsDefineIecst);
+        }
+    };
+
+1. Include the Registration Script
+----------------------------------
+Add this registration script using the ``revealjs_script_appended_files`` option::
+
+    revealjs_script_appended_files = [
+        "revealjs/plugin/highlight/register-iecst.js",
+    ]
+
+.. note::
+   - Replace ``iecst`` with the language you want to add.
+   - This process is required for any language marked as "package" in the Highlight.js table, as they are not bundled by default.
+   - The first script loads the language definition, and the second script registers it with Highlight.js after the plugin is ready.

--- a/sphinx_revealjs/__init__.py
+++ b/sphinx_revealjs/__init__.py
@@ -128,6 +128,7 @@ def setup(app: Sphinx):
     app.add_config_value("revealjs_js_files", [], "env")
     app.add_config_value("revealjs_css_files", [], "env")
     app.add_config_value("revealjs_script_files", [], "env")
+    app.add_config_value("revealjs_script_appended_files", [], "env")
     app.add_config_value("revealjs_script_conf", None, "env")
     app.add_config_value("revealjs_script_plugins", [], "env")
     app.add_html_theme("revealjs-basic", str(get_theme_path("revealjs-basic")))

--- a/sphinx_revealjs/builders.py
+++ b/sphinx_revealjs/builders.py
@@ -57,6 +57,10 @@ class RevealjsHTMLBuilder(StandaloneHTMLBuilder):
                 static_resource_uri(src)
                 for src in getattr(self.config, "revealjs_script_files", [])
             ],
+            [  # noqa: W503
+                static_resource_uri(src)
+                for src in getattr(self.config, "revealjs_script_appended_files", [])
+            ],
             script_conf,
             [
                 RevealjsPlugin(

--- a/sphinx_revealjs/contexts.py
+++ b/sphinx_revealjs/contexts.py
@@ -52,6 +52,7 @@ class RevealjsProjectContext:
         self,
         engine_version: int,
         script_files: Optional[list[str]] = None,
+        script_appended_files: Optional[list[str]] = None,
         script_conf: Optional[Union[str, dict]] = None,
         script_plugins: Optional[list[RevealjsPlugin]] = None,
     ):  # noqa
@@ -65,7 +66,12 @@ class RevealjsProjectContext:
             self.script_conf = json.dumps(script_conf)
         self.script_plugins = script_plugins or []
         self._script_files = script_files or []
+        self._script_appended_files = script_appended_files or []
 
     @property
     def script_files(self):  # noqa
         return [static_resource_uri(self.engine.js_path)] + self._script_files
+
+    @property
+    def script_appended_files(self):  # noqa
+        return self._script_appended_files

--- a/sphinx_revealjs/themes/revealjs-basic/page.html
+++ b/sphinx_revealjs/themes/revealjs-basic/page.html
@@ -20,12 +20,15 @@
     <script src="{{ pathto(script_file, 1) }}"></script>
     {% endfor %}
     {% if revealjs.engine.version == 4 %}
-      {% for plugin in revealjs.script_plugins -%}
-      <script src="{{ pathto(plugin.src, 1) }}"></script>
-      {% endfor %}
+    {% for plugin in revealjs.script_plugins -%}
+    <script src="{{ pathto(plugin.src, 1) }}"></script>
+    {% endfor %}
+    {% for script_appended_file in revealjs.script_appended_files %}
+    <script src="{{ pathto(script_appended_file, 1) }}"></script>
+    {% endfor %}
     {% endif %}
     <script>
-        var revealjsConfig = new Object();
+        if (typeof revealjsConfig === 'undefined') { var revealjsConfig = new Object(); }
         {% if revealjs.script_conf -%}
         Object.assign(revealjsConfig, {{ revealjs.script_conf }});
         {%- endif %}

--- a/sphinx_revealjs/themes/revealjs-simple/page.html
+++ b/sphinx_revealjs/themes/revealjs-simple/page.html
@@ -57,12 +57,15 @@
     <script src="{{ pathto(script_file, 1) }}"></script>
     {% endfor %}
     {% if revealjs.engine.version == 4 %}
-      {% for plugin in revealjs.script_plugins -%}
-      <script src="{{ pathto(plugin.src, 1) }}"></script>
-      {% endfor %}
+    {% for plugin in revealjs.script_plugins -%}
+    <script src="{{ pathto(plugin.src, 1) }}"></script>
+    {% endfor %}
+    {% for script_appended_file in revealjs.script_appended_files %}
+    <script src="{{ pathto(script_appended_file, 1) }}"></script>
+    {% endfor %}
     {% endif %}
     <script>
-      var revealjsConfig = new Object();
+      if (typeof revealjsConfig === 'undefined') { var revealjsConfig = new Object(); }
       {% if revealjs.script_conf -%}
       Object.assign(revealjsConfig, {{ revealjs.script_conf }});
       {%- endif %}


### PR DESCRIPTION
This would implement the second possible solution listed in #229, which also allows for more customisations.